### PR TITLE
Bump file-type from 16.5.3 to 17.1.2

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "esm": "^3.2.25",
     "express": "^4.17.1",
     "form-data": "^4.0.0",
-    "file-type": "^16.5.3",
+    "file-type": "^17.1.2",
     "fs": "^0.0.1-security",
     "qr-image": "^3.2.0",
     "got": "^11.8.3",


### PR DESCRIPTION
#Bumps [file-type](https://github.com/sindresorhus/file-type) from 16.5.3 to 17.1.2.
- [Release notes](https://github.com/sindresorhus/file-type/releases)
- [Commits](https://github.com/sindresorhus/file-type/compare/v16.5.3...v17.1.2)

---
updated-dependencies:
- dependency-name: file-type
  dependency-type: direct:production
  update-type: version-update:semver-major
...

Signed-off-by: dependabot[bot] <support@github.com>